### PR TITLE
Ensure submodules are initialised before building

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -13,6 +13,8 @@ task :compile do
   path = File.expand_path("ext/snowcrash/build/out/Release/#{prefix}libsnowcrash.#{FFI::Platform::LIBSUFFIX}", File.dirname(__FILE__))
   puts path
   if !File.exists?(path) || ENV['RECOMPILE']
+    puts "Initializing submodules (if required)..."
+    `git submodule update --init --recursive 2>/dev/null`
     puts "Compiling extension..."
     `cd #{File.expand_path("ext/snowcrash/")} && ./configure --shared && make`
     exit $?.exitstatus


### PR DESCRIPTION
This ensures that when building gem github or a cloned copy that submodules are checked out first.
