### PR TITLE
Allow require bundler/gem_tasks to fail if bundler is not found

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,9 @@
-require "bundler/gem_tasks"
+begin
+  require 'bundler/gem_tasks'
+rescue LoadError
+  puts "Cannot load bundler/gem_tasks"
+end
+
 require 'rake/testtask'
 require 'ffi'
 


### PR DESCRIPTION
When including as a gem in another project bundler won't be loaded during a bundle install.
In turn this means that although running gem install redsnow would work, attempting to add to
another project's gemfile and then running bundle install would not.
This allows the LoadError to be ignored and show a warning to stout so installation can continue.
