### PR TITLE
Default Parameter#use to :required when undefined

### DIFF
--- a/lib/redsnow/blueprint.rb
+++ b/lib/redsnow/blueprint.rb
@@ -160,6 +160,7 @@ module RedSnow
       @use =  RedSnow::Binding.sc_parameter_parameter_use(sc_parameter_handle)
       @default_value = RedSnow::Binding.sc_parameter_default_value(sc_parameter_handle)
       @example_value = RedSnow::Binding.sc_parameter_example_value(sc_parameter_handle)
+      @use = :required if @use == :undefined
 
       @values = Array.new
 

--- a/test/redsnow_test.rb
+++ b/test/redsnow_test.rb
@@ -251,7 +251,7 @@ class RedSnowParsingTest < Test::Unit::TestCase
 
       should "have parameters" do
         assert_equal 'id', @parameter.name
-        assert_equal :undefined, @parameter.use
+        assert_equal :required, @parameter.use
       end
     end
 


### PR DESCRIPTION
From my understanding of the API Blueprint documentation,
when a parameter is not specified to be required or optional
it is to be considered _required_ by _default_.

Here is where in the documentation I am forming this basis:
https://github.com/apiaryio/api-blueprint/blob/master/API%20Blueprint%20Specification.md#description-11

> - _required_ is the _optional_ specifier of a required parameter (this is the _default_)
