### PR TITLE
Add clarification on values of the use parameter

### DIFF
--- a/lib/redsnow/blueprint.rb
+++ b/lib/redsnow/blueprint.rb
@@ -139,7 +139,8 @@ module RedSnow
   #   represents one 'parameters section' parameter
   #
   # @attr type [String] an arbitrary type of the parameter or nil
-  # @attr use [Symbol] parameter necessity flag, `:required` or `:optional`
+  # @attr use [Symbol] parameter necessity flag, `:required`, `:optional` or :undefined
+  #    Where `:undefined` implies `:required` according to the API Blueprint Specification
   # @attr default_value [String] default value of the parameter or nil
   #   This is a value used when the parameter is ommited in the request.
   # @attr example_value [String] example value of the parameter or nil


### PR DESCRIPTION
Per https://github.com/apiaryio/redsnow/pull/40 this commits elaborates on the
values of the `use` parameter attribute
