### PR TITLE
Add resource_group getter to resource

### DIFF
--- a/lib/redsnow/blueprint.rb
+++ b/lib/redsnow/blueprint.rb
@@ -321,9 +321,11 @@ module RedSnow
     attr_accessor :model
     attr_accessor :parameters
     attr_accessor :actions
+    attr_reader :resource_group
 
     # @param sc_resource_handle [FFI::Pointer]
-    def initialize(sc_resource_handle)
+    def initialize(sc_resource_handle, resource_group)
+      @resource_group = resource_group
       @name = RedSnow::Binding.sc_resource_name(sc_resource_handle)
       @description = RedSnow::Binding.sc_resource_description(sc_resource_handle)
       @uri_template = RedSnow::Binding.sc_resource_uritemplate(sc_resource_handle)
@@ -370,7 +372,7 @@ module RedSnow
 
       (0..resource_size).each do |index|
         sc_resource_handle = RedSnow::Binding.sc_resource_handle(sc_resource_collection_handle, index)
-        @resources << Resource.new(sc_resource_handle)
+        @resources << Resource.new(sc_resource_handle, self)
       end
     end
   end

--- a/test/redsnow_test.rb
+++ b/test/redsnow_test.rb
@@ -138,6 +138,10 @@ class RedSnowParsingTest < Test::Unit::TestCase
         assert_equal 'text/plain', @resource.model.headers['Content-Type']
       end
 
+      should 'have a getter to its resource_group' do
+        assert_equal @resource.resource_group, @resource_group
+      end
+
       should 'have actions' do
         assert_equal 2, @resource.actions.count
         assert_equal 'GET', @action.method


### PR DESCRIPTION
Hello,

I'd like to suggest to include in RedSnow the ability to access the parent node on each blueprint node. For example, I think it'd be nice to be able to access the resource group of a resource using `resource.resource_group`. Same logic would apply to resource-actions, actions-transactional_examples, transactional_examples-requests/responses.

As a developer working with RedSnow I find a bit complicate that, in order to get all the information needed to perform a http request, I have to gather all the different objects and parameters to create this http request (action provides the method, resource provides the uri_template). I think it would be easier if I could just pass the response object, and use it to retrieve its related parents (`response.example, response.example.action, response.example.action.resource, response.example.action.resource.resource_group`)

In this pull request, I've just added the functionality to access the resource_group from resource, but I can do the same for actions, transactional_examples, requests, responses if you like the idea and think it is useful.

Thanks.
