### PR TITLE
Add parent getter to Actions/Examples/Payloads

### DIFF
--- a/lib/redsnow/blueprint.rb
+++ b/lib/redsnow/blueprint.rb
@@ -211,6 +211,7 @@ module RedSnow
     attr_accessor :body
     attr_accessor :schema
     attr_accessor :reference
+    attr_reader :example
 
     # @param sc_payload_handle_resource [FFI::Pointer]
     def initialize(sc_payload_handle_resource)
@@ -256,7 +257,9 @@ module RedSnow
 
         (0..requests_size).each do |index|
           sc_payload_handle = RedSnow::Binding.sc_payload_handle(sc_payload_collection_handle_requests, index)
-          @requests << Payload.new(sc_payload_handle)
+          @requests << Payload.new(sc_payload_handle).tap do |payload|
+            payload.instance_variable_set('@example', self)
+          end
         end
       end
 
@@ -271,7 +274,9 @@ module RedSnow
 
       (0..responses_size).each do |index|
         sc_payload_handle = RedSnow::Binding.sc_payload_handle(sc_payload_collection_handle_responses, index)
-        @responses << Payload.new(sc_payload_handle)
+        @responses << Payload.new(sc_payload_handle).tap do |payload|
+          payload.instance_variable_set('@example', self)
+        end
       end
     end
   end

--- a/test/redsnow_test.rb
+++ b/test/redsnow_test.rb
@@ -363,6 +363,8 @@ class RedSnowParsingTest < Test::Unit::TestCase
         assert_equal 'creating', @examples[0].requests[0].headers.collection[1][:value]
         assert_equal '201', @examples[0].responses[0].name
         assert_equal @action, @examples[0].action
+        assert_equal @examples[0], @examples[0].responses[0].example
+        assert_equal @examples[0], @examples[0].requests[0].example
         assert_equal 'Unable to create note', @examples[1].requests[0].name
         assert_equal 'Content-Type', @examples[1].requests[0].headers.collection[0][:name]
         assert_equal 'application/json', @examples[1].requests[0].headers['content-type']
@@ -371,6 +373,8 @@ class RedSnowParsingTest < Test::Unit::TestCase
         assert_equal '{ "ti": "Buy cheese and bread for breakfast." }' + "\n", @examples[1].requests[0].body
         assert_equal '500', @examples[1].responses[0].name
         assert_equal @action, @examples[1].action
+        assert_equal @examples[1], @examples[1].responses[0].example
+        assert_equal @examples[1], @examples[1].requests[0].example
       end
     end
   end


### PR DESCRIPTION
In actions and examples, I've added the same behavior as in Resources (#45)
In Payloads I have done something different though. I didn't want to include the parent object as part of the constructor since a Payload can be created for different purposes (E.G: Resource models). In this case, I have preferred to set the example using `instance_variable_set`.
