### PR TITLE
Allowing rake versions > 1.3

### DIFF
--- a/redsnow.gemspec
+++ b/redsnow.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |gem|
   gem.extensions   = %w(Rakefile)
 
   gem.add_dependency 'ffi', '~> 1.9.3'
-  gem.add_dependency 'rake', '~> 10.3.2'
+  gem.add_dependency 'rake', '>= 10.3.2'
   gem.add_dependency 'bundler', '~> 1.7.0'
   gem.add_dependency 'yard', '~> 0.8.7.4'
 


### PR DESCRIPTION
Not sure why the gem requires `rake <~ 1.3.2`, but this constraint makes it such that the library will not work with a Rails 4.2 app, since the latter requires `rake 1.4.*`. The test suite and everything seems to run correctly using `rake` 1.4.*, so I went ahead and removed the constraint. 
