### PR TITLE
Use minitest instead of test/unit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: ruby
 rvm:
 - 1.9.3
 - 2.1.0
+- "2.2"
 script:
 - rake test
 - rake install

--- a/redsnow.gemspec
+++ b/redsnow.gemspec
@@ -28,9 +28,9 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'bundler', '>= 1.7.0'
   gem.add_dependency 'yard', '~> 0.8.7.4'
 
+  gem.add_development_dependency 'minitest'
   gem.add_development_dependency 'shoulda'
   gem.add_development_dependency 'mocha'
-  gem.add_development_dependency 'turn'
   gem.add_development_dependency 'unindent'
   gem.add_development_dependency 'rubocop'
   gem.add_development_dependency 'guard-rubocop'

--- a/test/_helper.rb
+++ b/test/_helper.rb
@@ -1,12 +1,11 @@
 require 'bundler/setup'
 
-require 'test/unit'
+require 'minitest/autorun'
 require 'shoulda'
-require 'turn' unless ENV['TM_FILEPATH'] || ENV['CI']
 require 'mocha'
 require File.join(File.expand_path('../../lib/redsnow.rb', __FILE__))
 # Test Helper
-class TestHelper < Test::Unit::TestCase
+class TestHelper < Minitest::Test
   def fixture_file(name)
     File.read File.expand_path("../fixtures/#{name}", __FILE__)
   end

--- a/test/redsnow_binding_test.rb
+++ b/test/redsnow_binding_test.rb
@@ -1,7 +1,7 @@
 require '_helper'
 require 'json'
 # RedSnowBindingTest
-class RedSnowBindingTest < Test::Unit::TestCase
+class RedSnowBindingTest < Minitest::Test
   context 'RedSnow Binding' do
     should 'convert API Blueprint to AST' do
       parse_result = FFI::MemoryPointer.new :pointer
@@ -12,7 +12,7 @@ class RedSnowBindingTest < Test::Unit::TestCase
       assert !parse_result.null?
 
       parse_result_as_string = parse_result.null? ? nil : parse_result.read_string
-      assert_not_nil parse_result_as_string
+      refute_nil parse_result_as_string
 
       parsed = JSON.parse(parse_result_as_string)
 

--- a/test/redsnow_options_test.rb
+++ b/test/redsnow_options_test.rb
@@ -1,10 +1,10 @@
 require '_helper'
 # RedSnowOptionsTest
-class RedSnowOptionsTest < Test::Unit::TestCase
+class RedSnowOptionsTest < Minitest::Test
   context 'Test arguments' do
     context 'Arguments' do
       should "raise error if first parameter isn't String" do
-        exception = assert_raise(ArgumentError) { RedSnow.parse(1) }
+        exception = assert_raises(ArgumentError) { RedSnow.parse(1) }
         assert_equal('Expected string value', exception.message)
       end
 

--- a/test/redsnow_parseresult_test.rb
+++ b/test/redsnow_parseresult_test.rb
@@ -1,7 +1,7 @@
 require '_helper'
 require 'unindent'
 # RedSnowParseResultTest
-class RedSnowParseResultTest < Test::Unit::TestCase
+class RedSnowParseResultTest < Minitest::Test
   context 'Simple API' do
     setup do
       @result = RedSnow.parse('# My API', 4)

--- a/test/redsnow_sourcemap_test.rb
+++ b/test/redsnow_sourcemap_test.rb
@@ -1,7 +1,7 @@
 require '_helper'
 require 'unindent'
 # RedSnowParsingTest
-class RedSnowSourcemapTest < Test::Unit::TestCase
+class RedSnowSourcemapTest < Minitest::Test
   context 'API Blueprint parser' do
     context 'API' do
       setup do

--- a/test/redsnow_test.rb
+++ b/test/redsnow_test.rb
@@ -2,7 +2,7 @@ require '_helper'
 require 'unindent'
 
 # RedSnowParsingTest
-class RedSnowParsingAPITest < Test::Unit::TestCase
+class RedSnowParsingAPITest < Minitest::Test
   # https://github.com/apiaryio/protagonist/blob/master/test/parser-test.coffee
   context 'API' do
     setup do
@@ -30,7 +30,7 @@ class RedSnowParsingAPITest < Test::Unit::TestCase
   end
 end
 
-class RedSnowParsingGroupTest < Test::Unit::TestCase
+class RedSnowParsingGroupTest < Minitest::Test
   context 'Group' do
     setup do
       source = <<-STR
@@ -71,7 +71,7 @@ class RedSnowParsingGroupTest < Test::Unit::TestCase
   end
 end
 
-class RedSnowParsingResourceTest < Test::Unit::TestCase
+class RedSnowParsingResourceTest < Minitest::Test
   context 'Resource' do
     setup do
       source = <<-STR
@@ -156,7 +156,7 @@ class RedSnowParsingResourceTest < Test::Unit::TestCase
   end
 end
 
-class RedSnowParsingActionTest < Test::Unit::TestCase
+class RedSnowParsingActionTest < Minitest::Test
   context 'Action' do
     setup do
       source = <<-STR
@@ -208,7 +208,7 @@ class RedSnowParsingActionTest < Test::Unit::TestCase
   end
 end
 
-class RedSnowParsingMetadataTest < Test::Unit::TestCase
+class RedSnowParsingMetadataTest < Minitest::Test
   context 'parses blueprint metadata' do
     setup do
       source = <<-STR
@@ -249,7 +249,7 @@ class RedSnowParsingMetadataTest < Test::Unit::TestCase
   end
 end
 
-class RedSnowParsingParametersTest < Test::Unit::TestCase
+class RedSnowParsingParametersTest < Minitest::Test
   context 'parses action attributes' do
     setup do
       source = <<-STR
@@ -381,7 +381,7 @@ class RedSnowParsingParametersTest < Test::Unit::TestCase
   end
 end
 
-class RedSnowParsingMultipleTransactionsTest < Test::Unit::TestCase
+class RedSnowParsingMultipleTransactionsTest < Minitest::Test
   context 'parses multiple transactions' do
     setup do
       source = <<-STR


### PR DESCRIPTION
test/unit has been deprecated, and minitest is now the default test library in Ruby.

This also lets to build pass on Ruby 2.2