### PR TITLE
Prepare for release v0.4.2

### DIFF
--- a/lib/redsnow/version.rb
+++ b/lib/redsnow/version.rb
@@ -1,5 +1,5 @@
 # Module RedSnow
 module RedSnow
   # Gem version
-  VERSION = '0.4.1'
+  VERSION = '0.4.2'
 end


### PR DESCRIPTION
Updates drafter to v0.1.9 and supports ruby 2.2