### PR TITLE
Upgrade Yard dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,8 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in red_snow.gemspec
 gemspec
+
+# Lock dependencies for TravisCI builds using older Ruby versions
+gem 'activesupport', '< 5'
+gem 'listen', '< 3.1'
+gem 'rubocop', '~> 0.32.1'

--- a/redsnow.gemspec
+++ b/redsnow.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'ffi', '~> 1.9.3'
   gem.add_dependency 'rake', '>= 10.3.2'
   gem.add_dependency 'bundler', '>= 1.7.0'
-  gem.add_dependency 'yard', '~> 0.8.7.4'
+  gem.add_dependency 'yard', '~> 0.9.5'
 
   gem.add_development_dependency 'minitest'
   gem.add_development_dependency 'shoulda'


### PR DESCRIPTION
Earlier version of Yard is not compatible with Rake v11+

This fixes apiaryio/redsnow#74